### PR TITLE
Regex update for video/audio codec from MediaInfo

### DIFF
--- a/MediaInfo.py
+++ b/MediaInfo.py
@@ -147,7 +147,7 @@ class MediaInfo :
             mediaInfo['haveVideo'] = 1
             videoInfo = video.group(0)
 
-            videoCodec        = re.search("Codec\s*:\s*([\w\_\-\\\/\. ]+)\n",           videoInfo, re.S)
+            videoCodec        = re.search("Codec(?:\sID)?\s*:\s*([\w\_\-\\\/\. ]+)\n",  videoInfo, re.S)
             videoCodecProfile = re.search("Codec profile\s*:\s*([\w\_\-\\\/\@\. ]+)\n", videoInfo, re.S)
             videoDuration     = re.search("Duration\s*:\s*(\d+)\.?\d*\n",               videoInfo, re.S)
             videoBitrate      = re.search("Bit rate\s*:\s*(\d+)\n",                     videoInfo, re.S)
@@ -181,7 +181,7 @@ class MediaInfo :
             mediaInfo['haveAudio'] = 1
             audioInfo = audio.group(0)
 
-            tmpAudioCodec     = re.search("Codec\s*:\s*([\w\_\-\\\/ ]+)\n",             audioInfo, re.S)
+            tmpAudioCodec     = re.search("Codec(?:\sID)?\s*:\s*([\w\_\-\\\/ ]+)\n",    audioInfo, re.S)
             audioCodec        = re.search("\w+", tmpAudioCodec.group(1), re.S)
             audioCodecProfile = re.search("Codec profile\s*:\s*([\w\_\-\\\/\@\. ]+)\n", audioInfo, re.S)
             if audioCodecProfile is None :


### PR DESCRIPTION
MediaInfo output has at some point been changed from "Codec" to "Codec ID". This commit will support both existing and newer versions of MediaInfo output as the new regex contains an optional non-capturing group