### PR TITLE
Handle filenames with spaces in them

### DIFF
--- a/MediaInfo.py
+++ b/MediaInfo.py
@@ -173,7 +173,14 @@ class MediaInfo :
             mediaInfo['haveAudio'] = 1
             audioInfo = audio.group(0)
 
-            tmpAudioCodec     = re.search("Codec\s*:\s*([\w\_\-\\\/ ]+)\n",             audioInfo, re.S)
+            tmpAudioCodec     = re.search("Codec ID/Hint\s*:\s*([\w\_\-\\\/ ]+)\n",             audioInfo, re.S)
+
+            if not tmpAudioCodec:
+                tmpAudioCodec     = re.search("Codec ID\s*:\s*([\w\_\-\\\/ ]+)\n",             audioInfo, re.S)
+
+            if not tmpAudioCodec:
+                tmpAudioCodec     = re.search("Codec\s*:\s*([\w\_\-\\\/ ]+)\n",             audioInfo, re.S)
+
             audioCodec        = re.search("\w+", tmpAudioCodec.group(1), re.S)
             audioCodecProfile = re.search("Codec profile\s*:\s*([\w\_\-\\\/\@\. ]+)\n", audioInfo, re.S)
             if audioCodecProfile is None :

--- a/MediaInfo.py
+++ b/MediaInfo.py
@@ -44,7 +44,8 @@ class MediaInfo :
     def _ffmpegGetInfo(self) :
         cmd         = [self.cmd, "-loglevel", "quiet", "-print_format", "json",
                        "-show_format", "-show_streams", "-show_error",
-                       "-count_frames", "-i", self.filename]
+                       #"-count_frames",
+                       "-i", self.filename]
         outputBytes = ''
 
         try :

--- a/MediaInfo.py
+++ b/MediaInfo.py
@@ -12,6 +12,7 @@ class MediaInfo :
         self.filename = kwargs.get('filename')
         self.cmd      = kwargs.get('cmd')
         self.info     = dict()
+        self.infoDict = dict()
 
         if self.filename == None :
             self.filename = ''
@@ -60,6 +61,7 @@ class MediaInfo :
 
         try :
             infoDict = json.loads(sourceString)
+            self.infoDict = infoDict
         except json.JSONDecodeError as err :
             return mediaInfo
 

--- a/MediaInfo.py
+++ b/MediaInfo.py
@@ -41,12 +41,14 @@ class MediaInfo :
 
 
     def _ffmpegGetInfo(self) :
-        cmd         = self.cmd + ' -loglevel quiet -print_format json -show_format -show_streams -show_error -count_frames -i ' + self.filename
+        cmd         = [self.cmd, "-loglevel", "quiet", "-print_format", "json",
+                       "-show_format", "-show_streams", "-show_error",
+                       "-count_frames", "-i", self.filename]
         outputBytes = ''
 
         try :
-            outputBytes = subprocess.check_output(cmd, shell = True)
-        except subprocess.CalledProcessError as e :
+            outputBytes = subprocess.check_output(cmd, shell=False)
+        except subprocess.CalledProcessError as e:
             return ''
 
         outputText = outputBytes.decode('utf-8')
@@ -102,26 +104,14 @@ class MediaInfo :
         return mediaInfo
 
     def _mediainfoGetInfo(self) :
-        prevPath    = os.getcwd()
-        newPath     = os.path.abspath(os.path.dirname(self.filename))
-        file        = os.path.basename(self.filename)
-
-        cmd         = self.cmd + ' -f ' + file
-        outputBytes = ''
+        file_ = os.path.abspath(self.filename)
+        cmd = [self.cmd, "-f", file_]
 
         try :
-            os.chdir(newPath)
-            try :
-                outputBytes = subprocess.check_output(cmd, shell = True)
-            except subprocess.CalledProcessError as e :
-                return ''
-
+            outputBytes = subprocess.check_output(cmd, shell=False)
             outputText = outputBytes.decode('utf-8')
-        except IOError :
-            os.chdir(prevPath)
+        except Exception:
             return ''
-        finally:
-            os.chdir(prevPath)
 
         self.info  = self._mediainfoGetInfoRegex(outputText)
 


### PR DESCRIPTION
This allows filenames with spaces in them to work correctly.  My sonarr/radarr setup auto-renames all files to having spaces in them, so I needed this to work.

The trick is two-fold...  hand in the arguments to subprocess.check_output as a list, not a string... and do NOT use a shell to run an executable as the shell will also mess with the arguments.

While I was at it, I cleaned up the unnecessary changing of directories in the use of mediainfo.